### PR TITLE
Updated the Figure.js GatsbyJS component from caption to figcaption

### DIFF
--- a/template/web/src/components/Figure.js
+++ b/template/web/src/components/Figure.js
@@ -12,7 +12,7 @@ export default ({ node }) => {
   return (
     <figure>
       <Img fluid={fluidProps} alt={node.alt} />
-      <caption>{node.caption}</caption>
+      <figcaption>{node.caption}</figcaption>
     </figure>
   )
 }


### PR DESCRIPTION
Updated the Figure.js GatsbyJS component from caption to figcaption to fix a dom validation error - source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption. 
Here is the error in the console you'll see when using just `<caption>` tag within `<figure>`. 

<img width="1154" alt="Screen Shot 2019-06-21 at 11 08 48 AM" src="https://user-images.githubusercontent.com/727491/59939581-a5e54180-9415-11e9-8f5a-4216bb7b24b7.png">
