### PR TITLE
Fix typo in README template

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -22,7 +22,7 @@ Deployed from [sanity.io/create](https://www.sanity.io/create/?template=sanity-i
 ## Enable real-time content preview on development
 
 1. Go to your [project’s API settings on manage.sanity.io](https://manage.sanity.io/projects/<#< sanity.projectId >#>/settings/api) and create a token with read rights.
-2. Rename `.env.development.tenplate` to `.env.development` and paste in the token: `SANITY_READ_TOKEN="yourTokenHere"`.
+2. Rename `.env.development.template` to `.env.development` and paste in the token: `SANITY_READ_TOKEN="yourTokenHere"`.
 3. Restart the development server (`ctrl + C` and `npm run dev`).
 
 If you want to turn off preview you can set `watchMode: false` in gatsby-config.js. If you just want to preview published changes you can set `overlayDrafts: false` in gatsby-config.js.


### PR DESCRIPTION
Just noticed a tiny typo: "tenplate" instead of "template"