### PR TITLE
Remove dividers from Structure Menu Widget

### DIFF
--- a/template/studio/plugins/dashboard-widget-structure-menu/src/components/StructureMenuWidget.js
+++ b/template/studio/plugins/dashboard-widget-structure-menu/src/components/StructureMenuWidget.js
@@ -18,19 +18,24 @@ function StructureMenuWidget (props) {
       </div>
 
       <div className={styles.content}>
-        {props.structure.items.map(item => {
-          const Icon = getIconComponent(item)
-          return (
-            <div key={item.id}>
-              <Link className={styles.link} href={`/desk/${item.id}`}>
-                <div className={styles.iconWrapper}>
-                  <Icon />
-                </div>
-                <div>{item.title}</div>
-              </Link>
-            </div>
-          )
-        })}
+        {props.structure.items
+          .reduce((itemsWithoutDividers, item) => {
+            if (item.type !== 'divider') itemsWithoutDividers.push(item)
+            return itemsWithoutDividers
+          }, [])
+          .map(item => {
+            const Icon = getIconComponent(item)
+            return (
+              <div key={item.id}>
+                <Link className={styles.link} href={`/desk/${item.id}`}>
+                  <div className={styles.iconWrapper}>
+                    <Icon />
+                  </div>
+                  <div>{item.title}</div>
+                </Link>
+              </div>
+            )
+          })}
       </div>
     </div>
   )


### PR DESCRIPTION
Currently any dividers added inside of deskStructure.js will appear listed inside this widget as if they were valid navigation items, but with no title, which looks broken and is confusing for the users, also doesn't do anything useful. 

This filters out any dividers so they don't get listed as empty items.