### PR TITLE
Update Figure.js

### DIFF
--- a/template/web/src/components/Figure.js
+++ b/template/web/src/components/Figure.js
@@ -4,6 +4,7 @@ import {getFluidGatsbyImage} from 'gatsby-source-sanity'
 import clientConfig from '../../client-config'
 
 export default ({node}) => {
+  if (!node || !node.asset || !node.asset._id) { return null }
   const fluidProps = getFluidGatsbyImage(
     node.asset._id,
     {maxWidth: 675},


### PR DESCRIPTION
Add a check that the asset exists before we try to render it. User might be in the middle of adding it in the case of Gatsby Preview.