### PR TITLE
Update package.json

### DIFF
--- a/template/web/package.json
+++ b/template/web/package.json
@@ -31,8 +31,8 @@
     "postcss-import": "^12.0.1",
     "postcss-preset-env": "^6.6.0",
     "prettier-eslint-cli": "^4.7.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "react-helmet": "^5.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
React 17 is breaking this starter because hot-reloader depends on React 16.