### PR TITLE
Update .eslintignore

### DIFF
--- a/template/.eslintignore
+++ b/template/.eslintignore
@@ -1,2 +1,3 @@
 /web/public
-/studio/build
+/web/build
+/studio/dist


### PR DESCRIPTION
As far as I can tell, `/studio/build` doesn’t exist. Build code ends up in `studio/dist`, which can be verified by running the project or looking at [`/studio/.gitignore`](https://github.com/sanity-io/sanity-template-gatsby-blog/blob/main/template/studio/.gitignore).