### PR TITLE
Bugfix: display correct month date number

### DIFF
--- a/template/web/src/components/blog-post-preview.js
+++ b/template/web/src/components/blog-post-preview.js
@@ -34,7 +34,7 @@ function BlogPostPreview(props) {
           </div>
         )}
         <div className={styles.date}>
-          {format(new Date(props.publishedAt), "MMMM Mo, yyyy")}
+          {format(new Date(props.publishedAt), "MMMM do, yyyy")}
         </div>
       </div>
     </Link>

--- a/template/web/src/components/blog-post.js
+++ b/template/web/src/components/blog-post.js
@@ -42,7 +42,7 @@ function BlogPost(props) {
               <div className={styles.publishedAt}>
                 {differenceInDays(new Date(publishedAt), new Date()) > 3
                   ? formatDistance(new Date(publishedAt), new Date())
-                  : format(new Date(publishedAt), "MMMM Mo, yyyy")}
+                  : format(new Date(publishedAt), "MMMM do, yyyy")}
               </div>
             )}
             {authors && <AuthorList items={authors} title="Authors" />}


### PR DESCRIPTION
In date-fns, `Mo` displays the month number, not the date number as intended. Use `do` instead.

<img width="152" alt="image" src="https://user-images.githubusercontent.com/8071536/205483279-c3c6157a-63df-42a7-901f-77acb8df822a.png">
